### PR TITLE
Fix documented but broken "patternlab:build" task in Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -151,6 +151,7 @@ module.exports = function (grunt) {
   ******************************************************/
 
   grunt.registerTask('default', ['patternlab', 'copy:main']);
+  grunt.registerTask('patternlab:build', ['patternlab', 'copy:main']);
   grunt.registerTask('patternlab:watch', ['patternlab', 'copy:main', 'watch:all']);
   grunt.registerTask('patternlab:serve', ['patternlab', 'copy:main', 'browserSync', 'watch:all']);
 


### PR DESCRIPTION
Addresses #15 

**Summary of changes:**
Added a new grunt task that aliases the default task, which should be the desired behaviour.
