### PR TITLE
Copy CSS and JS sourcemaps if they exist

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,9 @@ module.exports = function (grunt) {
       main: {
         files: [
           { expand: true, cwd: path.resolve(paths().source.js), src: '**/*.js', dest: path.resolve(paths().public.js) },
+          { expand: true, cwd: path.resolve(paths().source.js), src: '**/*.js.map', dest: path.resolve(paths().public.js) },
           { expand: true, cwd: path.resolve(paths().source.css), src: '*.css', dest: path.resolve(paths().public.css) },
+          { expand: true, cwd: path.resolve(paths().source.css), src: '*.css.map', dest: path.resolve(paths().public.css) },
           { expand: true, cwd: path.resolve(paths().source.images), src: '*', dest: path.resolve(paths().public.images) },
           { expand: true, cwd: path.resolve(paths().source.fonts), src: '*', dest: path.resolve(paths().public.fonts) },
           { expand: true, cwd: path.resolve(paths().source.root), src: 'favicon.ico', dest: path.resolve(paths().public.root) },


### PR DESCRIPTION
Summary of changes:

Copies sourcemaps for CSS and JS into the public folder if they exist. This should help in the situation where pattern-lab is used as a development tool, as in-browser tools can pinpoint the affected lines in the source files.

There is no effect when none such `.map` files exist.

Should I also make a corresponding PR to the gulp project?
