### PR TITLE
Add clean arg to loadstarterkit in grunt file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,7 +53,7 @@ module.exports = function (grunt) {
     }
 
     if (arg && arg === "starterkit-load") {
-      pl.loadstarterkit(argv.kit);
+      pl.loadstarterkit(argv.kit, argv.clean);
     }
 
     if (arg && (arg !== "version" && arg !== "patternsonly" && arg !== "help" && arg !== "starterkit-list" && arg !== "starterkit-load")) {


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #12 (a portion)

Summary of changes: Added the argument for `--clean` to be passed to the loadstarterkit() function. This allows the clean to actually happen as it was not at all prior.
